### PR TITLE
adding support so that the module source can be a local path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,9 +49,9 @@ if [[ ! -s "$TFO_MAIN_MODULE_ADDONS/inline-module.tf" ]]; then
             done
         fi
     # Check if this is a source directory instead of a git repo
-    elif [[ $TFO_MAIN_MODULE_REPO == file://* ]]; then
-      local_module_path=${TFO_MAIN_MODULE_REPO#"file://"}
-      if [[ -d $local_module_path ]]; then
+    elif [[ "$TFO_MAIN_MODULE_REPO" == file://* ]]; then
+      local_module_path="${TFO_MAIN_MODULE_REPO#"file://"}"
+      if [[ -d "$local_module_path" ]]; then
         cp -r "$local_module_path" "$TFO_MAIN_MODULE"
       else
         echo "terraform module file source: $local_module_path, does not exist"

--- a/setup.sh
+++ b/setup.sh
@@ -49,8 +49,14 @@ if [[ ! -s "$TFO_MAIN_MODULE_ADDONS/inline-module.tf" ]]; then
             done
         fi
     # Check if this is a source directory instead of a git repo
-    elif [[ -d $TFO_MAIN_MODULE_REPO ]]; then
-        cp -r "$TFO_MAIN_MODULE_REPO" "$TFO_MAIN_MODULE"
+    elif [[ $TFO_MAIN_MODULE_REPO == file://* ]]; then
+      local_module_path=${TFO_MAIN_MODULE_REPO#"file://"}
+      if [[ -d $local_module_path ]]; then
+        cp -r "$local_module_path" "$TFO_MAIN_MODULE"
+      else
+        echo "terraform module file source: $local_module_path, does not exist"
+        exit 1
+      fi
     else
         # The terraform module is a repo that must be downloaded
         MAIN_MODULE_TMP=`mktemp -d`

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,9 @@ if [[ ! -s "$TFO_MAIN_MODULE_ADDONS/inline-module.tf" ]]; then
                 jq -r --arg key "$key" '.data[$key]' <<< $configmap_json > "${TFO_MAIN_MODULE}/${key}"
             done
         fi
+    # Check if this is a source directory instead of a git repo
+    elif [[ -d $TFO_MAIN_MODULE_REPO ]]; then
+        cp -r "$TFO_MAIN_MODULE_REPO" "$TFO_MAIN_MODULE"
     else
         # The terraform module is a repo that must be downloaded
         MAIN_MODULE_TMP=`mktemp -d`


### PR DESCRIPTION
In some pipelines artifacts are created as docker images from source and decoupled from source. If you make this modification to the setup.sh script it supports the ability for the module to be local (baked into the image). You can then create a docker image with the terraform image as the base and add your terraform code to a defined path like '/src'.

The only issue I think I have is that I'd like to have the entire source directory accessible even if it's running the create_file module.

Use case is if you have shared modules in the same source/directory..

example directory structure..

/src/modules/shared_module_1
/src/modules/shared_module_2
/src/modules/shared_module_3
/src/create_file

All of these files would be checked into source somewhere, but that source upon commit would generate a docker image.

We already have a pipeline that allows us to release/promote docker images as an artifact from nonprod envs to prod envs, this process works better for us than your traditional gitops where everything is tied directly to source.

It also allows for acquiring other companies that might be on SVN or TFS (you'd eventually want to migrate them to git) 
where it doesn't prohibit you from getting the applications into the pipeline since the universal artifact is a docker image which you can create from any source control system.

```
apiVersion: tf.isaaguilar.com/v1alpha2
kind: Terraform
metadata:
  name: hello-tfo
  namespace: "default"
spec:
  terraformVersion: 1.3.0-beta1
  terraformModule:
    source: /src/create_file

  images:
    terraform:
      image: some-customer-terraform-image:1.0.0
  backend: |-
    terraform {
      backend "kubernetes" {
        secret_suffix    = "hello-tfo"
        in_cluster_config  = true
        namespace = "default"
      }
    }

  keepCompletedPods: true
  ignoreDelete: true
```